### PR TITLE
Updated Fuel Dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,11 +34,11 @@
 buildscript {
     ext.versions = [
             // Kotlin
-            kotlinVersion     : '1.3.61',
+            kotlinVersion     : '1.6.21',
             coroutines        : '1.3.2',
 
             // Gradle
-            gradle            : '3.5.3',
+            gradle            : '7.1.2',
 
             // Virgil
             virgilSdk         : '7.2.0',
@@ -48,7 +48,7 @@ buildscript {
             gson              : '2.8.6',
 
             // Network
-            fuel              : '1.15.1',
+            fuel              : '2.3.1',
 
             // Android
             android           : '4.1.1.4',

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ buildscript {
 
             // Publish
             mavenPublishPlugin: '3.6.2',
-            dokka             : '0.9.17',
+            dokka             : '1.6.21',
 
             // Tests
             testsRunner       : '1.2.0',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,39 +1,6 @@
-#
-# Copyright (c) 2015-2020, Virgil Security, Inc.
-#
-# Lead Maintainer: Virgil Security Inc. <support@virgilsecurity.com>
-#
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#  
-#     (1) Redistributions of source code must retain the above copyright notice, this
-#     list of conditions and the following disclaimer.
-#
-#     (2) Redistributions in binary form must reproduce the above copyright notice,
-#     this list of conditions and the following disclaimer in the documentation
-#     and/or other materials provided with the distribution.
-#
-#     (3) Neither the name of virgil nor the names of its
-#     contributors may be used to endorse or promote products derived from
-#     this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
-
-#Sat Jan 11 16:56:12 EET 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
+#Sun Sep 01 23:54:57 EEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/pythia-android/build.gradle
+++ b/pythia-android/build.gradle
@@ -99,7 +99,7 @@ task sourcesJar(type: Jar) {
     classifier = 'sources'
 }
 
-task javadocJar(type: Jar, dependsOn: 'dokka') {
+task javadocJar(type: Jar, dependsOn: 'dokkaHtml') {
     from("$buildDir/javadoc")
     classifier = 'javadoc'
 }

--- a/pythia-android/build.gradle
+++ b/pythia-android/build.gradle
@@ -165,8 +165,6 @@ signing {
     sign publishing.publications.mavenJava
 }
 
-dokka {
-    outputFormat = 'html'
-    outputDirectory = "$buildDir/javadoc"
-    reportUndocumented = false
+dokkaHtml {
+    outputDirectory.set(file("$buildDir/javadoc"))
 }

--- a/pythia/build.gradle
+++ b/pythia/build.gradle
@@ -35,7 +35,7 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'signing'
-    id 'maven'
+//    id 'maven'
 }
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
Fuel Dependency was preventing the lib from downloading since it was hosted on JCenter and JCenter has shutdown completely, therefore I updated the Fuel dependency to use the new version from MavenCentral.